### PR TITLE
Ability to use ServiceProvider during configuration

### DIFF
--- a/benchmarks/Jobby.Benchmarks/JobbyBenchmarks/JobbyBulkCreateJobsBenchmark.cs
+++ b/benchmarks/Jobby.Benchmarks/JobbyBenchmarks/JobbyBulkCreateJobsBenchmark.cs
@@ -28,7 +28,7 @@ public class JobbyBulkCreateJobsBenchmarkAction
     public JobbyBulkCreateJobsBenchmarkAction()
     {
         var dataSource = DataSourceFactory.Create();
-        var builder = new JobbyServicesBuilder();
+        var builder = new JobbyBuilder();
         builder.UsePostgresql(dataSource);
         _jobbyClient = builder.CreateJobbyClient();
     }

--- a/benchmarks/Jobby.Benchmarks/JobbyBenchmarks/JobbyCreateJobsBenchmark.cs
+++ b/benchmarks/Jobby.Benchmarks/JobbyBenchmarks/JobbyCreateJobsBenchmark.cs
@@ -28,7 +28,7 @@ public class JobbyCreateJobsBenchmarkAction
     public JobbyCreateJobsBenchmarkAction()
     {
         var dataSource = DataSourceFactory.Create();
-        var builder = new JobbyServicesBuilder();
+        var builder = new JobbyBuilder();
         builder.UsePostgresql(dataSource);
         _jobbyClient = builder.CreateJobbyClient();
     }

--- a/benchmarks/Jobby.Benchmarks/JobbyBenchmarks/JobbyExecuteJobsBenchmark.cs
+++ b/benchmarks/Jobby.Benchmarks/JobbyBenchmarks/JobbyExecuteJobsBenchmark.cs
@@ -98,12 +98,13 @@ public class JobbyExecuteJobsBenchmarkAction
         };
         var scopeFactory = new JobbyTestExecutionScopeFactory();
 
-        var builder = new JobbyServicesBuilder();
+        var builder = new JobbyBuilder();
+        builder.AddJob<JobbyTestJobCommand, JobbyTestJobCommandHandler>();
         builder
             .UsePostgresql(_dataSource)
             .UseServerSettings(serverSettings)
-            .UseExecutionScopeFactory(scopeFactory)
-            .AddJob<JobbyTestJobCommand, JobbyTestJobCommandHandler>();
+            .UseExecutionScopeFactory(scopeFactory);
+            
 
         _jobbyServer = builder.CreateJobbyServer();
         _jobbyClient = builder.CreateJobbyClient();

--- a/docs/en/overview.md
+++ b/docs/en/overview.md
@@ -76,33 +76,36 @@ public class SendEmailCommandHandler : IJobCommandHandler<SendEmailCommand>
 
 #### ASP.NET Core Configuration  
 
-To add Jobby to an ASP.NET Core application, use the `AddJobby` extension method:  
+To add Jobby to an ASP.NET Core application, use the `AddJobbyServerAndClient` extension method:  
 
 ```csharp
-var dataSource = NpgsqlDataSource.Create(databaseConnectionString);  
+builder.Services.AddSingleton<NpgsqlDataSource>(NpgsqlDataSource.Create(databaseConnectionString));
 
-builder.Services.AddJobby(jobbyBuilder =>  
-{  
-    jobbyBuilder  
-        .UsePostgresql(dataSource)  
-        .UseServerSettings(new JobbyServerSettings  
+builder.Services.AddJobbyServerAndClient(jobbyBuilder =>  
+{
+    // Specify assemblies containing your IJobCommand and IJobCommandHandler implementations  
+    jobbyBuilder.AddJobsFromAssemblies(typeof(SendEmailCommand).Assembly);
+
+    // Configure jobby
+    jobbyBuilder.ConfigureJobby((serviceProvider, jobby) => {
+        jobby.UsePostgresql(serviceProvider.GetRequiredService<NpgsqlDataSource>());  
+        jobby.UseServerSettings(new JobbyServerSettings  
         {  
             // Maximum number of concurrently executing tasks  
             MaxDegreeOfParallelism = 10,  
 
             // Maximum number of tasks fetched from queue per query  
             TakeToProcessingBatchSize = 10,  
-        })  
-        .UseDefaultRetryPolicy(new RetryPolicy  
+        });
+        jobby.UseDefaultRetryPolicy(new RetryPolicy  
         {  
             // Maximum number of task execution attempts  
             MaxCount = 3,  
 
             // Delays between retry attempts (in seconds)  
-            IntervalsSeconds = [1, 2]  
-        })  
-        // Assemblies containing your IJobCommand and IJobCommandHandler implementations  
-        .AddJobsFromAssemblies(typeof(SendEmailCommand).Assembly);  
+            IntervalsSeconds = [1, 2]
+        });
+    }); 
 });  
 ```
 
@@ -110,10 +113,10 @@ Full ASP.NET Core example: [Jobby.Samples.AspNet](https://github.com/fornit1917/
 
 #### Non-ASP.NET Core Configuration  
 
-For non-ASP.NET Core usage, create a `JobbyServicesBuilder` instance:  
+For non-ASP.NET Core usage, create a `JobbyBuilder` instance:  
 
 ```csharp
-var jobbyBuilder = new JobbyServicesBuilder();  
+var jobbyBuilder = new JobbyBuilder();  
 jobbyBuilder  
         .UsePostgresql(dataSource)  
         // scopeFactory - your custom scope factory implementation  
@@ -134,7 +137,7 @@ Full console application example: [Jobby.Samples.CliJobsSample](https://github.c
 
 ### Enqueueing Tasks  
 
-Use the `IJobbyClient` service to enqueue tasks (available via DI in ASP.NET Core or from `JobbyServicesBuilder` otherwise).  
+Use the `IJobbyClient` service to enqueue tasks (available via DI in ASP.NET Core or from `JobbyBuilder` otherwise).  
 
 #### Single Task  
 

--- a/samples/Jobby.Samples.CliJobsSample/Program.cs
+++ b/samples/Jobby.Samples.CliJobsSample/Program.cs
@@ -39,7 +39,8 @@ internal class Program
             IntervalsSeconds = [1]
         };
 
-        var builder = new JobbyServicesBuilder();
+        var builder = new JobbyBuilder();
+        builder.AddJobsFromAssemblies(typeof(TestCliJobCommand).Assembly);
         builder
             .UsePostgresql(pgOpts =>
             {
@@ -49,8 +50,8 @@ internal class Program
             .UseSystemTextJson(jsonOptions)
             .UseExecutionScopeFactory(scopeFactory)
             .UseDefaultRetryPolicy(defaultRetryPolicy)
-            .UseLoggerFactory(loggerFactory)
-            .AddJobsFromAssemblies(typeof(TestCliJobCommand).Assembly);
+            .UseLoggerFactory(loggerFactory);
+            
 
         var jobbyServer = builder.CreateJobbyServer();
         var jobbyClient = builder.CreateJobbyClient();

--- a/src/Jobby.AspNetCore/AspNetCoreJobbyBuilder.cs
+++ b/src/Jobby.AspNetCore/AspNetCoreJobbyBuilder.cs
@@ -1,0 +1,52 @@
+﻿using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Configuration;
+using Jobby.Core.Services;
+using System.Reflection;
+
+namespace Jobby.AspNetCore;
+
+internal class AspNetCoreJobbyBuilder : IAspNetCoreJobbyConfigurable
+{
+    public JobbyBuilder JobbyBuilder { get; } = new JobbyBuilder();
+
+    private Action<IServiceProvider, IJobbyComponentsConfigurable>? _jobbyComponentsConfigureAction;
+
+    public IAspNetCoreJobbyConfigurable AddJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>
+    {
+        JobbyBuilder.AddJob<TCommand, THandler>();
+        return this;
+    }
+
+    public IAspNetCoreJobbyConfigurable AddJobsFromAssemblies(params Assembly[] assemblies)
+    {
+        JobbyBuilder.AddJobsFromAssemblies(assemblies);
+        return this;
+    }
+
+    public IAspNetCoreJobbyConfigurable AddOrReplaceJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>
+    {
+        JobbyBuilder.AddOrReplaceJob<TCommand, THandler>();
+        return this;
+    }
+
+    public IAspNetCoreJobbyConfigurable ConfigureJobby(Action<IJobbyComponentsConfigurable> configure)
+    {
+        configure(JobbyBuilder);
+        return this;
+    }
+
+    public IAspNetCoreJobbyConfigurable ConfigureJobby(Action<IServiceProvider, IJobbyComponentsConfigurable> configure)
+    {
+        _jobbyComponentsConfigureAction = configure;
+        return this;
+    }
+
+    public void ApplyJobbyComponentsConfigureAction(IServiceProvider sp)
+    {
+        _jobbyComponentsConfigureAction?.Invoke(sp, JobbyBuilder);
+    }
+}

--- a/src/Jobby.AspNetCore/IAspNetCoreJobbyConfigurable.cs
+++ b/src/Jobby.AspNetCore/IAspNetCoreJobbyConfigurable.cs
@@ -1,0 +1,21 @@
+﻿using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Configuration;
+using System.Reflection;
+
+namespace Jobby.AspNetCore;
+
+public interface IAspNetCoreJobbyConfigurable
+{
+    IAspNetCoreJobbyConfigurable ConfigureJobby(Action<IJobbyComponentsConfigurable> configure);
+    IAspNetCoreJobbyConfigurable ConfigureJobby(Action<IServiceProvider, IJobbyComponentsConfigurable> configure);
+
+    IAspNetCoreJobbyConfigurable AddJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>;
+
+    IAspNetCoreJobbyConfigurable AddOrReplaceJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>;
+
+    IAspNetCoreJobbyConfigurable AddJobsFromAssemblies(params Assembly[] assemblies);
+}

--- a/src/Jobby.Core/Interfaces/Configuration/IJobbyComponentsConfigurable.cs
+++ b/src/Jobby.Core/Interfaces/Configuration/IJobbyComponentsConfigurable.cs
@@ -1,0 +1,22 @@
+﻿using Jobby.Core.Models;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Jobby.Core.Interfaces.Configuration;
+
+public interface IJobbyComponentsConfigurable
+{
+    IJobbyComponentsConfigurable UseStorage(IJobbyStorage storage);
+
+    IJobbyComponentsConfigurable UseLoggerFactory(ILoggerFactory loggerFactory);
+
+    IJobbyComponentsConfigurable UseSerializer(IJobParamSerializer serializer);
+    IJobbyComponentsConfigurable UseSystemTextJson(JsonSerializerOptions jsonOptions);
+
+    IJobbyComponentsConfigurable UseServerSettings(JobbyServerSettings settings);
+
+    IJobbyComponentsConfigurable UseExecutionScopeFactory(IJobExecutionScopeFactory scopeFactory);
+
+    IJobbyComponentsConfigurable UseDefaultRetryPolicy(RetryPolicy retryPolicy);
+    IJobbyComponentsConfigurable UseRetryPolicyForJob<TCommand>(RetryPolicy retryPolicy) where TCommand : IJobCommand;
+}

--- a/src/Jobby.Core/Interfaces/Configuration/IJobbyJobsConfigurable.cs
+++ b/src/Jobby.Core/Interfaces/Configuration/IJobbyJobsConfigurable.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace Jobby.Core.Interfaces.Configuration;
+
+public interface IJobbyJobsConfigurable
+{
+    IJobbyJobsConfigurable AddJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>;
+
+    IJobbyJobsConfigurable AddOrReplaceJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>;
+
+    IJobbyJobsConfigurable AddJobsFromAssemblies(params Assembly[] assemblies);
+}

--- a/src/Jobby.Core/Interfaces/IJobbyServicesConfigurable.cs
+++ b/src/Jobby.Core/Interfaces/IJobbyServicesConfigurable.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 
 namespace Jobby.Core.Interfaces;
 
+[Obsolete("Use IJobbyComponentsConfigurable and IJobbyJobsConfigurable instead of IJobbyServicesConfigurable. It will be removed in 1.0.0")]
 public interface IJobbyServicesConfigurable
 {
     IJobbyServicesConfigurable UseStorage(IJobbyStorage storage);

--- a/src/Jobby.Core/Jobby.Core.csproj
+++ b/src/Jobby.Core/Jobby.Core.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     </ItemGroup>
     <ItemGroup>
-       <None Include="../../docs/logo/jobby_package_icon.png" Pack="true" PackagePath="\"/>
-       <None Include="../../docs/en/overview.md" Pack="true" PackagePath="\"/>
+       <None Include="../../docs/logo/jobby_package_icon.png" Pack="true" PackagePath="\" />
+       <None Include="../../docs/en/overview.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/src/Jobby.Core/Services/JobbyBuilder.cs
+++ b/src/Jobby.Core/Services/JobbyBuilder.cs
@@ -1,0 +1,239 @@
+﻿using Jobby.Core.Exceptions;
+using Jobby.Core.Helpers;
+using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Configuration;
+using Jobby.Core.Models;
+using Microsoft.Extensions.Logging;
+using System.Collections.Frozen;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Jobby.Core.Services;
+
+public class JobbyBuilder : IJobbyComponentsConfigurable, IJobbyJobsConfigurable
+{
+    private IJobbyStorage? _storage;
+    private IJobExecutionScopeFactory? _scopeFactory;
+    private ILoggerFactory? _loggerFactory;
+    private IJobParamSerializer? _serializer;
+    private IJobsFactory? _jobsFactory;
+
+    private RetryPolicy _defaultRetryPolicy = RetryPolicy.NoRetry;
+    private Dictionary<string, RetryPolicy> _retryPolicyByJobName = new Dictionary<string, RetryPolicy>();
+    private IRetryPolicyService? _retryPolicyService;
+
+    private readonly Dictionary<string, IJobExecutorFactory> _jobExecutorFactoriesByJobName = new();
+    private IJobsRegistry? _jobsRegistry;
+
+    public bool IsExecutionScopeFactorySpecified => _scopeFactory != null;
+    public bool IsLoggerFactorySpecified => _loggerFactory != null;
+    public IEnumerable<JobTypesMetadata> AddedJobTypes => _jobExecutorFactoriesByJobName.Values.Select(x => x.GetJobTypesMetadata());
+
+    private JobbyServerSettings _serverSettings = new JobbyServerSettings();
+
+    public IJobbyServer CreateJobbyServer()
+    {
+        if (_storage == null)
+        {
+            throw new InvalidBuilderConfigException("Storage is not specified");
+        }
+
+        if (_scopeFactory == null)
+        {
+            throw new InvalidBuilderConfigException("ExecutionScopeFactory is not specified");
+        }
+
+        if (_serializer == null)
+        {
+            _serializer = new SystemTextJsonJobParamSerializer(new JsonSerializerOptions());
+        }
+
+        if (_loggerFactory == null)
+        {
+            _loggerFactory = new EmptyLoggerFactory();
+        }
+
+        if (_retryPolicyService == null)
+        {
+            _retryPolicyService = new RetryPolicyService(_defaultRetryPolicy, _retryPolicyByJobName);
+        }
+
+        if (_jobsRegistry == null)
+        {
+            _jobsRegistry = new JobsRegistry(_jobExecutorFactoriesByJobName.ToFrozenDictionary());
+        }
+
+        var serverId = $"{Environment.MachineName}_{Guid.NewGuid()}";
+
+        IJobCompletionService completionService = _serverSettings.CompleteWithBatching
+            ? new BatchingJobCompletionService(_storage, _serverSettings, serverId)
+            : new SimpleJobCompletionService(_storage, _serverSettings.DeleteCompleted, serverId);
+
+        IJobPostProcessingService postProcessingService = new JobPostProcessingService(_storage,
+            completionService,
+            _loggerFactory.CreateLogger<JobPostProcessingService>(),
+            serverId);
+
+        IJobExecutionService executionService = new JobExecutionService(_scopeFactory,
+            _jobsRegistry,
+            _retryPolicyService,
+            _serializer,
+            postProcessingService,
+            _loggerFactory.CreateLogger<JobExecutionService>());
+
+        return new JobbyServer(_storage,
+            executionService,
+            postProcessingService,
+            _loggerFactory.CreateLogger<JobbyServer>(),
+            _serverSettings,
+            serverId);
+    }
+
+    public IJobbyClient CreateJobbyClient()
+    {
+        if (_storage == null)
+        {
+            throw new InvalidBuilderConfigException("Jobs storage is not specified");
+        }
+
+        return new JobbyClient(CreateJobsFactory(), _storage);
+    }
+
+    public IJobsFactory CreateJobsFactory()
+    {
+        if (_jobsFactory == null)
+        {
+            if (_serializer == null)
+            {
+                _serializer = new SystemTextJsonJobParamSerializer(new JsonSerializerOptions());
+            }
+            _jobsFactory = new JobsFactory(_serializer);
+        }
+        return _jobsFactory;
+    }
+
+    public IJobbyComponentsConfigurable UseExecutionScopeFactory(IJobExecutionScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseServerSettings(JobbyServerSettings serverSettings)
+    {
+        _serverSettings = serverSettings;
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseStorage(IJobbyStorage storage)
+    {
+        _storage = storage;
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseSystemTextJson(JsonSerializerOptions jsonOptions)
+    {
+        UseSerializer(new SystemTextJsonJobParamSerializer(jsonOptions));
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseSerializer(IJobParamSerializer serializer)
+    {
+        _serializer = serializer;
+        _jobsFactory = new JobsFactory(_serializer);
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseDefaultRetryPolicy(RetryPolicy retryPolicy)
+    {
+        _defaultRetryPolicy = retryPolicy;
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseRetryPolicyForJob<TCommand>(RetryPolicy retryPolicy) where TCommand : IJobCommand
+    {
+        _retryPolicyByJobName[TCommand.GetJobName()] = retryPolicy;
+        return this;
+    }
+
+    public IJobbyJobsConfigurable AddJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>
+    {
+        var jobName = TCommand.GetJobName();
+        if (!_jobExecutorFactoriesByJobName.TryAdd(jobName, new JobExecutorFactory<TCommand, THandler>()))
+        {
+            throw new InvalidJobsConfigException($"Handler for {typeof(TCommand)} has already been added");
+        }
+        return this;
+    }
+
+    public IJobbyJobsConfigurable AddOrReplaceJob<TCommand, THandler>()
+        where TCommand : IJobCommand
+        where THandler : IJobCommandHandler<TCommand>
+    {
+        var jobName = TCommand.GetJobName();
+        _jobExecutorFactoriesByJobName[jobName] = new JobExecutorFactory<TCommand, THandler>();
+        return this;
+    }
+
+    public IJobbyJobsConfigurable AddJobsFromAssemblies(params Assembly[] assemblies)
+    {
+        var commandTypesByJobName = new Dictionary<string, Type>();
+        var handlerImplTypesByCommandType = new Dictionary<Type, Type>();
+
+        var notAbstractTypes = assemblies.SelectMany(a => a.GetTypes()).Where(a => !a.IsAbstract);
+
+        foreach (var t in notAbstractTypes)
+        {
+            var jobName = ReflectionHelper.TryGetJobNameByType(t);
+            if (jobName != null)
+            {
+                if (!commandTypesByJobName.TryAdd(jobName, t))
+                {
+                    var error = $"Each implementation of IJobCommand must return unique value from GetJobName method, but name '{jobName}' is used in two commands: {commandTypesByJobName} and {t}";
+                    throw new InvalidJobsConfigException(error);
+                }
+            }
+
+            var commandFromHandler = ReflectionHelper.TryGetCommandTypeFromHandlerType(t);
+            if (commandFromHandler != null)
+            {
+                if (!handlerImplTypesByCommandType.TryAdd(commandFromHandler, t))
+                {
+                    var error = $"Each job command must have single handler, but command {commandFromHandler} has two handlers: {handlerImplTypesByCommandType[t]} and {t}";
+                    throw new InvalidJobsConfigException(error);
+                }
+            }
+        }
+
+        foreach (var keyVal in commandTypesByJobName)
+        {
+            var jobName = keyVal.Key;
+            var commandType = keyVal.Value;
+
+            if (!handlerImplTypesByCommandType.TryGetValue(commandType, out var handlerImplType))
+            {
+                var error = $"Command {commandType} does not have handler. IJobCommandHandler<> should be implemented for this type";
+                throw new InvalidJobsConfigException(error);
+            }
+
+            var jobExecutorFactoryType = typeof(JobExecutorFactory<,>).MakeGenericType(commandType, handlerImplType);
+            var jobExecutorFactory = Activator.CreateInstance(jobExecutorFactoryType) as IJobExecutorFactory;
+
+            if (jobExecutorFactory is null)
+            {
+                throw new InvalidJobsConfigException($"Could not create instance of JobExecutorFactory with type {jobExecutorFactoryType}");
+            }
+
+            _jobExecutorFactoriesByJobName.Add(jobName, jobExecutorFactory);
+        }
+
+        return this;
+    }
+}

--- a/src/Jobby.Core/Services/JobbyServicesBuilder.cs
+++ b/src/Jobby.Core/Services/JobbyServicesBuilder.cs
@@ -1,137 +1,56 @@
-﻿using Jobby.Core.Exceptions;
-using Jobby.Core.Helpers;
-using Jobby.Core.Interfaces;
+﻿using Jobby.Core.Interfaces;
 using Jobby.Core.Models;
 using Microsoft.Extensions.Logging;
-using System.Collections.Frozen;
 using System.Reflection;
 using System.Text.Json;
 
 namespace Jobby.Core.Services;
 
+[Obsolete("Use JobbyBuilder instead of JobbyServicesBuilder. Will be removed in 1.0.0")]
 public class JobbyServicesBuilder : IJobbyServicesConfigurable
 {
-    private IJobbyStorage? _storage;
-    private IJobExecutionScopeFactory? _scopeFactory;
-    private ILoggerFactory? _loggerFactory;
-    private IJobParamSerializer? _serializer;
-    private IJobsFactory? _jobsFactory;
+    private readonly JobbyBuilder _jobbyBuilder = new JobbyBuilder();
 
-    private RetryPolicy _defaultRetryPolicy = RetryPolicy.NoRetry;
-    private Dictionary<string, RetryPolicy> _retryPolicyByJobName = new Dictionary<string, RetryPolicy>();
-    private IRetryPolicyService? _retryPolicyService;
-
-    private readonly Dictionary<string, IJobExecutorFactory> _jobExecutorFactoriesByJobName = new();
-    private IJobsRegistry? _jobsRegistry;
-
-    public bool IsExecutionScopeFactorySpecified => _scopeFactory != null;
-    public bool IsLoggerFactorySpecified => _loggerFactory != null;
-    public IEnumerable<JobTypesMetadata> AddedJobTypes => _jobExecutorFactoriesByJobName.Values.Select(x => x.GetJobTypesMetadata());
-
-    private JobbyServerSettings _serverSettings = new JobbyServerSettings();
+    public bool IsExecutionScopeFactorySpecified => _jobbyBuilder.IsExecutionScopeFactorySpecified;
+    public bool IsLoggerFactorySpecified => _jobbyBuilder.IsLoggerFactorySpecified;
+    public IEnumerable<JobTypesMetadata> AddedJobTypes => _jobbyBuilder.AddedJobTypes;
 
     public IJobbyServer CreateJobbyServer()
     {
-        if (_storage == null)
-        {
-            throw new InvalidBuilderConfigException("Storage is not specified");
-        }
-
-        if (_scopeFactory == null)
-        {
-            throw new InvalidBuilderConfigException("ExecutionScopeFactory is not specified");
-        }
-
-        if (_serializer == null)
-        {
-            _serializer = new SystemTextJsonJobParamSerializer(new JsonSerializerOptions());
-        }
-
-        if (_loggerFactory == null)
-        {
-            _loggerFactory = new EmptyLoggerFactory();
-        }
-
-        if (_retryPolicyService == null)
-        {
-            _retryPolicyService = new RetryPolicyService(_defaultRetryPolicy, _retryPolicyByJobName);
-        }
-
-        if (_jobsRegistry == null)
-        {
-            _jobsRegistry = new JobsRegistry(_jobExecutorFactoriesByJobName.ToFrozenDictionary());
-        }
-
-        var serverId = $"{Environment.MachineName}_{Guid.NewGuid()}";
-
-        IJobCompletionService completionService = _serverSettings.CompleteWithBatching
-            ? new BatchingJobCompletionService(_storage, _serverSettings, serverId)
-            : new SimpleJobCompletionService(_storage, _serverSettings.DeleteCompleted, serverId);
-
-        IJobPostProcessingService postProcessingService = new JobPostProcessingService(_storage,
-            completionService,
-            _loggerFactory.CreateLogger<JobPostProcessingService>(),
-            serverId);
-
-        IJobExecutionService executionService = new JobExecutionService(_scopeFactory,
-            _jobsRegistry,
-            _retryPolicyService,
-            _serializer,
-            postProcessingService,
-            _loggerFactory.CreateLogger<JobExecutionService>());
-
-        return new JobbyServer(_storage,
-            executionService,
-            postProcessingService,
-            _loggerFactory.CreateLogger<JobbyServer>(),
-            _serverSettings,
-            serverId);
+        return _jobbyBuilder.CreateJobbyServer();
     }
 
     public IJobbyClient CreateJobbyClient()
     {
-        if (_storage == null)
-        {
-            throw new InvalidBuilderConfigException("Jobs storage is not specified");
-        }
-    
-        return new JobbyClient(CreateJobsFactory(), _storage);
+        return _jobbyBuilder.CreateJobbyClient();
     }
 
     public IJobsFactory CreateJobsFactory()
     {
-        if (_jobsFactory == null)
-        {
-            if (_serializer == null)
-            {
-                _serializer = new SystemTextJsonJobParamSerializer(new JsonSerializerOptions());
-            }
-            _jobsFactory = new JobsFactory(_serializer);
-        }
-        return _jobsFactory;
+        return _jobbyBuilder.CreateJobsFactory();
     }
 
     public IJobbyServicesConfigurable UseExecutionScopeFactory(IJobExecutionScopeFactory scopeFactory)
     {
-        _scopeFactory = scopeFactory;
+        _jobbyBuilder.UseExecutionScopeFactory(scopeFactory);
         return this;
     }
 
     public IJobbyServicesConfigurable UseLoggerFactory(ILoggerFactory loggerFactory)
     {
-        _loggerFactory = loggerFactory;
+        _jobbyBuilder.UseLoggerFactory(loggerFactory);
         return this;
     }
 
     public IJobbyServicesConfigurable UseServerSettings(JobbyServerSettings serverSettings)
     {
-        _serverSettings = serverSettings;
+        _jobbyBuilder.UseServerSettings(serverSettings);
         return this;
     }
 
     public IJobbyServicesConfigurable UseStorage(IJobbyStorage storage)
     {
-        _storage = storage;
+        _jobbyBuilder.UseStorage(storage);
         return this;
     }
 
@@ -143,20 +62,19 @@ public class JobbyServicesBuilder : IJobbyServicesConfigurable
 
     public IJobbyServicesConfigurable UseSerializer(IJobParamSerializer serializer)
     {
-        _serializer = serializer;
-        _jobsFactory = new JobsFactory(_serializer);
+        _jobbyBuilder.UseSerializer(serializer);
         return this;
     }
 
     public IJobbyServicesConfigurable UseDefaultRetryPolicy(RetryPolicy retryPolicy)
     {
-        _defaultRetryPolicy = retryPolicy;
+        _jobbyBuilder.UseDefaultRetryPolicy(retryPolicy);
         return this;
     }
 
     public IJobbyServicesConfigurable UseRetryPolicyForJob<TCommand>(RetryPolicy retryPolicy) where TCommand : IJobCommand
     {
-        _retryPolicyByJobName[TCommand.GetJobName()] = retryPolicy;
+        _jobbyBuilder.UseRetryPolicyForJob<TCommand>(retryPolicy);
         return this;
     }
 
@@ -164,11 +82,7 @@ public class JobbyServicesBuilder : IJobbyServicesConfigurable
         where TCommand : IJobCommand
         where THandler : IJobCommandHandler<TCommand>
     {
-        var jobName = TCommand.GetJobName();
-        if (!_jobExecutorFactoriesByJobName.TryAdd(jobName, new JobExecutorFactory<TCommand, THandler>()))
-        {
-            throw new InvalidJobsConfigException($"Handler for {typeof(TCommand)} has already been added");
-        }
+        _jobbyBuilder.AddJob<TCommand, THandler>();
         return this;
     }
 
@@ -176,63 +90,13 @@ public class JobbyServicesBuilder : IJobbyServicesConfigurable
         where TCommand : IJobCommand
         where THandler : IJobCommandHandler<TCommand>
     {
-        var jobName = TCommand.GetJobName();
-        _jobExecutorFactoriesByJobName[jobName] = new JobExecutorFactory<TCommand, THandler>();
+        _jobbyBuilder.AddOrReplaceJob<TCommand, THandler>();
         return this;
     }
 
     public IJobbyServicesConfigurable AddJobsFromAssemblies(params Assembly[] assemblies)
     {
-        var commandTypesByJobName = new Dictionary<string, Type>();
-        var handlerImplTypesByCommandType = new Dictionary<Type, Type>();
-
-        var notAbstractTypes = assemblies.SelectMany(a => a.GetTypes()).Where(a => !a.IsAbstract);
-
-        foreach (var t in notAbstractTypes)
-        {
-            var jobName = ReflectionHelper.TryGetJobNameByType(t);
-            if (jobName != null)
-            {
-                if (!commandTypesByJobName.TryAdd(jobName, t))
-                {
-                    var error = $"Each implementation of IJobCommand must return unique value from GetJobName method, but name '{jobName}' is used in two commands: {commandTypesByJobName} and {t}";
-                    throw new InvalidJobsConfigException(error);
-                }
-            }
-
-            var commandFromHandler = ReflectionHelper.TryGetCommandTypeFromHandlerType(t);
-            if (commandFromHandler != null)
-            {
-                if (!handlerImplTypesByCommandType.TryAdd(commandFromHandler, t))
-                {
-                    var error = $"Each job command must have single handler, but command {commandFromHandler} has two handlers: {handlerImplTypesByCommandType[t]} and {t}";
-                    throw new InvalidJobsConfigException(error);
-                }
-            }
-        }
-
-        foreach (var keyVal in commandTypesByJobName)
-        {
-            var jobName = keyVal.Key;
-            var commandType = keyVal.Value;
-
-            if (!handlerImplTypesByCommandType.TryGetValue(commandType, out var handlerImplType))
-            {
-                var error = $"Command {commandType} does not have handler. IJobCommandHandler<> should be implemented for this type";
-                throw new InvalidJobsConfigException(error);
-            }
-
-            var jobExecutorFactoryType = typeof(JobExecutorFactory<,>).MakeGenericType(commandType, handlerImplType);
-            var jobExecutorFactory = Activator.CreateInstance(jobExecutorFactoryType) as IJobExecutorFactory;
-
-            if (jobExecutorFactory is null)
-            {
-                throw new InvalidJobsConfigException($"Could not create instance of JobExecutorFactory with type {jobExecutorFactoryType}");
-            }
-
-            _jobExecutorFactoriesByJobName.Add(jobName, jobExecutorFactory);
-        }
-
+        _jobbyBuilder.AddJobsFromAssemblies(assemblies);
         return this;
     }
 }

--- a/src/Jobby.Postgres/ConfigurationExtensions/JobbyPostgresqlConfigurationExtensions.cs
+++ b/src/Jobby.Postgres/ConfigurationExtensions/JobbyPostgresqlConfigurationExtensions.cs
@@ -1,10 +1,30 @@
 ﻿using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Configuration;
 using Npgsql;
 
 namespace Jobby.Postgres.ConfigurationExtensions;
 
 public static class JobbyPostgresqlConfigurationExtensions
 {
+    public static IJobbyComponentsConfigurable UsePostgresql(this IJobbyComponentsConfigurable opts, Action<IPostgresqlStorageConfigurable> configure)
+    {
+        var builder = new PostgresqlStorageBuilder();
+        configure(builder);
+        var storage = builder.Build();
+        opts.UseStorage(storage);
+        return opts;
+    }
+
+    public static IJobbyComponentsConfigurable UsePostgresql(this IJobbyComponentsConfigurable opts, NpgsqlDataSource dataSource)
+    {
+        var builder = new PostgresqlStorageBuilder();
+        builder.UseDataSource(dataSource);
+        var storage = builder.Build();
+        opts.UseStorage(storage);
+        return opts;
+    }
+
+    [Obsolete("Use IJobbyComponentsConfigurable instead of IJobbyServicesConfigurable")]
     public static IJobbyServicesConfigurable UsePostgresql(this IJobbyServicesConfigurable opts, Action<IPostgresqlStorageConfigurable> configure)
     {
         var builder = new PostgresqlStorageBuilder();
@@ -14,6 +34,7 @@ public static class JobbyPostgresqlConfigurationExtensions
         return opts;
     }
 
+    [Obsolete("Use IJobbyComponentsConfigurable instead of IJobbyServicesConfigurable")]
     public static IJobbyServicesConfigurable UsePostgresql(this IJobbyServicesConfigurable opts, NpgsqlDataSource dataSource)
     {
         var builder = new PostgresqlStorageBuilder();

--- a/tests/Jobby.IntegrationTests.Postgres/Helpers/FactoryHelper.cs
+++ b/tests/Jobby.IntegrationTests.Postgres/Helpers/FactoryHelper.cs
@@ -8,7 +8,7 @@ namespace Jobby.IntegrationTests.Postgres.Helpers;
 
 public class FactoryHelper
 {
-    private static readonly JobbyServicesBuilder _builder = new JobbyServicesBuilder();
+    private static readonly JobbyBuilder _builder = new JobbyBuilder();
     private static readonly IJobbyStorage _storage = DbHelper.CreateJobbyStorage();
     public static ExecutedCommandsList ExecutedCommands { get; } = new ExecutedCommandsList();
 

--- a/tests/Jobby.Tests.AspNetCore/AspNetCoreJobbyBuilderTests.cs
+++ b/tests/Jobby.Tests.AspNetCore/AspNetCoreJobbyBuilderTests.cs
@@ -1,0 +1,43 @@
+﻿using Jobby.AspNetCore;
+using Jobby.Core.Interfaces.Configuration;
+using Moq;
+
+namespace Jobby.Tests.AspNetCore;
+
+public class AspNetCoreJobbyBuilderTests
+{
+    [Fact]
+    public void ApplyJobbyComponentsConfigureAction_CallsConfigureActionAndPassesServiceProvider()
+    {
+        var builder = new AspNetCoreJobbyBuilder();
+        IServiceProvider? passedServiceProvider = null;
+        IServiceProvider serviceProvider = new Mock<IServiceProvider>().Object;
+        IJobbyComponentsConfigurable? passedComponentsConfigurable = null;
+        Action<IServiceProvider, IJobbyComponentsConfigurable> configure = (sp, opts) =>
+        {
+            passedServiceProvider = sp;
+            passedComponentsConfigurable = opts;
+        };
+
+        builder.ConfigureJobby(configure);
+        builder.ApplyJobbyComponentsConfigureAction(serviceProvider);
+
+        Assert.Equal(serviceProvider, passedServiceProvider);
+        Assert.Equal(builder.JobbyBuilder, passedComponentsConfigurable);
+    }
+
+    [Fact]
+    public void ConfigureJobby_WithoutServiceProvider_CallsConfigureAction()
+    {
+        var builder = new AspNetCoreJobbyBuilder();
+        IJobbyComponentsConfigurable? passedComponentsConfigurable = null;
+        Action<IJobbyComponentsConfigurable> configure = (opts) =>
+        {
+            passedComponentsConfigurable = opts;
+        };
+
+        builder.ConfigureJobby(configure);
+
+        Assert.Equal(builder.JobbyBuilder, passedComponentsConfigurable);
+    }
+}


### PR DESCRIPTION
Implementation of https://github.com/fornit1917/jobby/issues/4 

Added ability to use IServiceProvider during configuration:

```csharp
builder.Services.AddSingleton<NpgsqlDataSource>(NpgsqlDataSource.Create(databaseConnectionString));

builder.Services.AddJobbyServerAndClient(jobbyBuilder =>  
{
    // Specify assemblies containing your IJobCommand and IJobCommandHandler implementations  
    jobbyBuilder.AddJobsFromAssemblies(typeof(SendEmailCommand).Assembly);

    // Configure jobby
    jobbyBuilder.ConfigureJobby((serviceProvider, jobby) => {
        jobby.UsePostgresql(serviceProvider.GetRequiredService<NpgsqlDataSource>());  
        jobby.UseServerSettings(new JobbyServerSettings  
        {  
            // Maximum number of concurrently executing tasks  
            MaxDegreeOfParallelism = 10,  

            // Maximum number of tasks fetched from queue per query  
            TakeToProcessingBatchSize = 10,  
        });
        jobby.UseDefaultRetryPolicy(new RetryPolicy  
        {  
            // Maximum number of task execution attempts  
            MaxCount = 3,  

            // Delays between retry attempts (in seconds)  
            IntervalsSeconds = [1, 2]
        });
    }); 
});
```