### PR TITLE
Jitter for RetryPolicy

### DIFF
--- a/samples/Jobby.Samples.CliJobsSample/Program.cs
+++ b/samples/Jobby.Samples.CliJobsSample/Program.cs
@@ -36,7 +36,8 @@ internal class Program
         var defaultRetryPolicy = new RetryPolicy
         {
             MaxCount = 3,
-            IntervalsSeconds = [1]
+            IntervalsSeconds = [1],
+            JitterMaxValuesMs = [500]
         };
 
         var builder = new JobbyBuilder();

--- a/src/Jobby.Core/Models/RetryPolicy.cs
+++ b/src/Jobby.Core/Models/RetryPolicy.cs
@@ -6,6 +6,7 @@ public class RetryPolicy
 
     public int MaxCount { get; init; }
     public IReadOnlyList<int> IntervalsSeconds { get; init; } = Array.Empty<int>();
+    public IReadOnlyList<int> JitterMaxValuesMs { get; init; } = Array.Empty<int>();
 
     public TimeSpan? GetIntervalForNextAttempt(JobExecutionModel job)
     {
@@ -21,6 +22,16 @@ public class RetryPolicy
             intervalSeconds = IntervalsSeconds.Count > intervalIndex
                 ? IntervalsSeconds[intervalIndex]
                 : IntervalsSeconds[IntervalsSeconds.Count - 1];
+        }
+
+        if (JitterMaxValuesMs.Count > 0)
+        {
+            var jitterMaxMs = JitterMaxValuesMs.Count > intervalIndex
+                ? JitterMaxValuesMs[intervalIndex]
+                : JitterMaxValuesMs[JitterMaxValuesMs.Count - 1];
+            var jitterMs = Random.Shared.Next(jitterMaxMs + 1);
+
+            return TimeSpan.FromMilliseconds(intervalSeconds * 1000 + jitterMs);
         }
 
         return TimeSpan.FromSeconds(intervalSeconds);

--- a/tests/Jobby.Tests.Core/Models/RetryPolicyTests.cs
+++ b/tests/Jobby.Tests.Core/Models/RetryPolicyTests.cs
@@ -51,4 +51,21 @@ public class RetryPolicyTests
         var interval4 = retryPolicy.GetIntervalForNextAttempt(job);
         Assert.Null(interval4);
     }
+
+    [Fact]
+    public void JitterSpecified_ReturnsIntervalWithJitter()
+    {
+        var retryPolicy = new RetryPolicy
+        {
+            MaxCount = 4,
+            IntervalsSeconds = [10, 20],
+            JitterMaxValuesMs = [1000]
+        };
+
+        var job = new JobExecutionModel { StartedCount = 1 };
+        var interval = retryPolicy.GetIntervalForNextAttempt(job);
+
+        var intervalWithoutJitter = TimeSpan.FromSeconds(10);
+        Assert.True(interval > intervalWithoutJitter);
+    }
 }


### PR DESCRIPTION
Implemented Jitter for RetryPolicy: random additional delay for intervals between attempts.

For example, this RetryPolicy will retry failed job with random interval from 1 to 1.5 seconds

```
var defaultRetryPolicy = new RetryPolicy
{
    MaxCount = 3,
    IntervalsSeconds = [1],
    JitterMaxValuesMs = [500]
};
```