### PR TITLE
Custom schedulers for recurrent jobs

### DIFF
--- a/samples/Jobby.Samples.AspNet/Controllers/JobsController.cs
+++ b/samples/Jobby.Samples.AspNet/Controllers/JobsController.cs
@@ -2,6 +2,7 @@
 using Jobby.Core.Models;
 using Jobby.Samples.AspNet.Db;
 using Jobby.Samples.AspNet.Jobs;
+using Jobby.Samples.AspNet.Schedulers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Jobby.Samples.AspNet.Controllers;
@@ -67,14 +68,32 @@ public class JobsController
     public async Task<string> ScheduleRecurrent([FromBody] string cron = "*/5 * * * * *")
     {
         var command = new EmptyRecurrentJobCommand();
-        await _jobbyClient.ScheduleRecurrentAsync(command, cron);
-        return "ok";
+        var jobId = await _jobbyClient.ScheduleRecurrentAsync(command, cron);
+        return jobId.ToString();
+    }
+
+    [HttpPost("schedule-recurrent-with-custom-scheduler")]
+    public async Task<string> ScheduleRecurrentWithCustomScheduler([FromBody] string secondsInterval)
+    {
+        var command = new CustomSchedulerRecurrentJobCommand();
+        var jobId = await _jobbyClient.ScheduleRecurrentAsync(command, secondsInterval, CustomSecondsScheduler.Name, new RecurrentJobOpts()
+        {
+            StartTime = DateTime.UtcNow,
+        });
+        return jobId.ToString();
     }
 
     [HttpPost("cancel-recurrent")]
     public async Task<string> CancelRecurrent()
     {
         await _jobbyClient.CancelRecurrentAsync<EmptyRecurrentJobCommand>();
+        return "ok";
+    }
+    
+    [HttpPost("cancel-recurrent-with-custom-scheduler")]
+    public async Task<string> CancelRecurrentWithCustomScheduler()
+    {
+        await _jobbyClient.CancelRecurrentAsync<CustomSchedulerRecurrentJobCommand>();
         return "ok";
     }
 }

--- a/samples/Jobby.Samples.AspNet/Jobs/CustomSchedulerRecurrentJobCommand.cs
+++ b/samples/Jobby.Samples.AspNet/Jobs/CustomSchedulerRecurrentJobCommand.cs
@@ -1,0 +1,25 @@
+﻿using Jobby.Core.Interfaces;
+using Jobby.Core.Models;
+
+namespace Jobby.Samples.AspNet.Jobs;
+
+public class CustomSchedulerRecurrentJobCommand : IJobCommand
+{
+    public static string GetJobName() => nameof(CustomSchedulerRecurrentJobCommand);
+}
+
+public class CustomSchedulerRecurrentJobCommandHandler : IJobCommandHandler<CustomSchedulerRecurrentJobCommand>
+{
+    private readonly ILogger<CustomSchedulerRecurrentJobCommandHandler> _logger;
+
+    public CustomSchedulerRecurrentJobCommandHandler(ILogger<CustomSchedulerRecurrentJobCommandHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task ExecuteAsync(CustomSchedulerRecurrentJobCommand command, JobExecutionContext ctx)
+    {
+        _logger.LogInformation("CustomSchedulerRecurrentJob executed, {Time}", DateTime.UtcNow);
+        return Task.CompletedTask;
+    }
+}

--- a/samples/Jobby.Samples.AspNet/Program.cs
+++ b/samples/Jobby.Samples.AspNet/Program.cs
@@ -6,6 +6,7 @@ using Jobby.Postgres.ConfigurationExtensions;
 using Jobby.Samples.AspNet.Db;
 using Jobby.Samples.AspNet.Jobs;
 using Jobby.Samples.AspNet.JobsMiddlewares;
+using Jobby.Samples.AspNet.Schedulers;
 using Jobby.Samples.AspNet.Settings;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -69,6 +70,7 @@ public static class Program
                         MaxCount = 3,
                         IntervalsSeconds = [1, 2]
                     })
+                    .UseScheduler(CustomSecondsScheduler.Name, new CustomSecondsScheduler())
                     .ConfigurePipeline(pipeline =>
                     {   
                         // Some custom middlewares

--- a/samples/Jobby.Samples.AspNet/Schedulers/CustomSecondsScheduler.cs
+++ b/samples/Jobby.Samples.AspNet/Schedulers/CustomSecondsScheduler.cs
@@ -1,0 +1,14 @@
+﻿using Jobby.Core.Interfaces.Schedulers;
+
+namespace Jobby.Samples.AspNet.Schedulers;
+
+public class CustomSecondsScheduler : IScheduler
+{
+    public const string Name = "CUSTOM_SECONDS";
+    
+    public DateTime GetNextStartTime(string schedule, DateTime? previousScheduledStartTime)
+    {
+        var seconds = int.Parse(schedule);
+        return previousScheduledStartTime?.AddSeconds(seconds) ?? DateTime.UtcNow;
+    }
+}

--- a/src/Jobby.Core/Exceptions/UnknownSchedulerTypeException.cs
+++ b/src/Jobby.Core/Exceptions/UnknownSchedulerTypeException.cs
@@ -1,0 +1,8 @@
+﻿namespace Jobby.Core.Exceptions;
+
+public class UnknownSchedulerTypeException : Exception
+{
+    public UnknownSchedulerTypeException(string message) : base(message)
+    {
+    }
+}

--- a/src/Jobby.Core/Helpers/CronHelper.cs
+++ b/src/Jobby.Core/Helpers/CronHelper.cs
@@ -3,7 +3,7 @@ using Jobby.Core.Exceptions;
 
 namespace Jobby.Core.Helpers;
 
-internal static class CronHelper
+public static class CronHelper
 {
     public static DateTime GetNext(string cron, DateTime from)
     {

--- a/src/Jobby.Core/Interfaces/Configuration/IJobbyComponentsConfigurable.cs
+++ b/src/Jobby.Core/Interfaces/Configuration/IJobbyComponentsConfigurable.cs
@@ -1,6 +1,7 @@
 ﻿using Jobby.Core.Models;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
+using Jobby.Core.Interfaces.Schedulers;
 
 namespace Jobby.Core.Interfaces.Configuration;
 
@@ -28,4 +29,6 @@ public interface IJobbyComponentsConfigurable
 
     IJobbyComponentsConfigurable UseMetrics();
     IJobbyComponentsConfigurable UseTracing();
+    
+    IJobbyComponentsConfigurable UseScheduler(string schedulerType, IScheduler scheduler);
 }

--- a/src/Jobby.Core/Interfaces/IJobbyClient.cs
+++ b/src/Jobby.Core/Interfaces/IJobbyClient.cs
@@ -6,11 +6,8 @@ public interface IJobbyClient
 {
     public IJobsFactory Factory { get; }
 
-    Task<Guid> EnqueueCommandAsync<TCommand>(TCommand command, JobOpts opts = default) 
-        where TCommand : IJobCommand;
-    
-    Task<Guid> EnqueueCommandAsync<TCommand>(TCommand command, DateTime startTime)
-        where TCommand : IJobCommand;
+    Task<Guid> EnqueueCommandAsync<TCommand>(TCommand command, JobOpts opts = default) where TCommand : IJobCommand;
+    Task<Guid> EnqueueCommandAsync<TCommand>(TCommand command, DateTime startTime) where TCommand : IJobCommand;
     
     Guid EnqueueCommand<TCommand>(TCommand command, JobOpts opts = default) where TCommand : IJobCommand;
     Guid EnqueueCommand<TCommand>(TCommand command, DateTime startTime) where TCommand : IJobCommand;
@@ -21,12 +18,24 @@ public interface IJobbyClient
     Task EnqueueBatchAsync(IReadOnlyList<JobCreationModel> jobs);
     void EnqueueBatch(IReadOnlyList<JobCreationModel> jobs);
 
-    Task ScheduleRecurrentAsync<TCommand>(TCommand command, string cron, RecurrentJobOpts opts = default)
-        where TCommand : IJobCommand;
+    Task<Guid> ScheduleRecurrentAsync<TCommand>(TCommand command,
+        string cron,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand;
     
-    void ScheduleRecurrent<TCommand>(TCommand command, string cron, RecurrentJobOpts opts = default)
-        where TCommand : IJobCommand;
-
+    Task<Guid> ScheduleRecurrentAsync<TCommand>(TCommand command, 
+        string schedule, 
+        string schedulerType, 
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand;
+    
+    Guid ScheduleRecurrent<TCommand>(TCommand command, 
+        string cron, 
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand;
+    
+    Guid ScheduleRecurrent<TCommand>(TCommand command, 
+        string schedule, 
+        string schedulerType, 
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand;
+    
     Task CancelRecurrentAsync<TCommand>() where TCommand : IJobCommand;
     void CancelRecurrent<TCommand>() where TCommand : IJobCommand;
 }

--- a/src/Jobby.Core/Interfaces/IJobsFactory.cs
+++ b/src/Jobby.Core/Interfaces/IJobsFactory.cs
@@ -8,8 +8,14 @@ public interface IJobsFactory
     JobCreationModel Create<TCommand>(TCommand command, JobOpts opts = default) where TCommand : IJobCommand;
     JobCreationModel Create<TCommand>(TCommand command, DateTime startTime) where TCommand : IJobCommand;
     
-    JobCreationModel CreateRecurrent<TCommand>(TCommand command, string cron, RecurrentJobOpts opts = default)
-        where TCommand : IJobCommand;
+    JobCreationModel CreateRecurrent<TCommand>(TCommand command, 
+        string cron,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand;
+    
+    JobCreationModel CreateRecurrent<TCommand>(TCommand command,
+        string schedule,
+        string schedulerType,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand;
 
     JobsSequenceBuilder CreateSequenceBuilder();
     JobsSequenceBuilder CreateSequenceBuilder(int capacity);

--- a/src/Jobby.Core/Interfaces/ITimerService.cs
+++ b/src/Jobby.Core/Interfaces/ITimerService.cs
@@ -5,4 +5,5 @@ internal interface ITimerService
     Task Delay(int milliseconds);
     long GetCurrentTicks();
     TimeSpan GetElapsedTime(long startTicks);
+    DateTime GetUtcNow();
 }

--- a/src/Jobby.Core/Interfaces/Schedulers/IScheduler.cs
+++ b/src/Jobby.Core/Interfaces/Schedulers/IScheduler.cs
@@ -1,0 +1,6 @@
+﻿namespace Jobby.Core.Interfaces.Schedulers;
+
+public interface IScheduler
+{
+    DateTime GetNextStartTime(string schedule, DateTime? previousScheduledStartTime);
+}

--- a/src/Jobby.Core/Models/JobCreationModel.cs
+++ b/src/Jobby.Core/Models/JobCreationModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Jobby.Core.Models;
+﻿using Jobby.Core.Services.Schedulers;
+
+namespace Jobby.Core.Models;
 
 public class JobCreationModel
 {
@@ -6,6 +8,7 @@ public class JobCreationModel
     public string JobName { get; internal set; } = string.Empty;
     public string? JobParam { get; internal set; }
     public string? Cron { get; internal set; }
+    public string? SchedulerType { get; internal set; }
     public bool IsExclusive { get; internal set; }
     public JobStatus Status { get; internal set; }
     public DateTime CreatedAt { get; internal set; }

--- a/src/Jobby.Core/Models/JobExecutionModel.cs
+++ b/src/Jobby.Core/Models/JobExecutionModel.cs
@@ -5,6 +5,7 @@ public class JobExecutionModel
     public Guid Id { get; init; }
     public string JobName { get; init; } = string.Empty;
     public string? Cron { get; init; }
+    public string? SchedulerType { get; init; }
     public string? JobParam { get; init; }
     public DateTime ScheduledStartAt { get; init; }
     public int StartedCount { get; init; }

--- a/src/Jobby.Core/Services/JobPostProcessingService.cs
+++ b/src/Jobby.Core/Services/JobPostProcessingService.cs
@@ -1,8 +1,9 @@
-﻿using Jobby.Core.Helpers;
-using Jobby.Core.Interfaces;
+﻿using Jobby.Core.Interfaces;
 using Jobby.Core.Models;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
+using Jobby.Core.Interfaces.Schedulers;
+using Jobby.Core.Services.Schedulers;
 
 namespace Jobby.Core.Services;
 
@@ -10,22 +11,22 @@ internal class JobPostProcessingService : IJobPostProcessingService
 {
     private readonly IJobbyStorage _storage;
     private readonly IJobCompletionService _jobCompletingService;
+    private readonly IReadOnlyDictionary<string, IScheduler> _schedulersByType;
     private readonly ILogger<JobPostProcessingService> _logger;
-    private readonly string _serverId;
 
     private readonly record struct RetryQueueItem(JobExecutionModel Job, RetryPolicy? RetryPolicy = null, string? Error = null);
     private readonly ConcurrentQueue<RetryQueueItem> _retryQueue;
 
     public JobPostProcessingService(IJobbyStorage storage,
         IJobCompletionService jobCompletingService,
-        ILogger<JobPostProcessingService> logger,
-        string serverId)
+        IReadOnlyDictionary<string, IScheduler> schedulersByType,
+        ILogger<JobPostProcessingService> logger)
     {
         _storage = storage;
         _jobCompletingService = jobCompletingService;
+        _schedulersByType = schedulersByType;
         _logger = logger;
         _retryQueue = new ConcurrentQueue<RetryQueueItem>();
-        _serverId = serverId;
     }
 
     public bool IsRetryQueueEmpty => _retryQueue.IsEmpty;
@@ -117,7 +118,20 @@ internal class JobPostProcessingService : IJobPostProcessingService
     private Task RescheduleRecurrentInternal(JobExecutionModel job, string? error)
     {
         ArgumentNullException.ThrowIfNull(job.Cron, nameof(job.Cron));
-        var nextStartAt = CronHelper.GetNext(job.Cron, DateTime.UtcNow);
+
+        DateTime nextStartAt;
+        var schedulerType = job.SchedulerType ?? JobbySchedulerTypes.CronFromNow;
+        if (!_schedulersByType.TryGetValue(schedulerType, out var scheduler))
+        {
+            nextStartAt = DateTime.UtcNow.Add(TimeSpan.FromMinutes(1));
+            _logger.LogError("Recurrent job {JobName} with id={JobId} has invalid SchedulerType: {SchedulerType}", 
+                job.JobName, job.Id, schedulerType);
+        }
+        else
+        {
+            nextStartAt = scheduler.GetNextStartTime(job.Cron, job.ScheduledStartAt); 
+        }
+        
         return _storage.RescheduleProcessingJobAsync(job, nextStartAt, error);
     }
 

--- a/src/Jobby.Core/Services/JobbyBuilder.cs
+++ b/src/Jobby.Core/Services/JobbyBuilder.cs
@@ -10,7 +10,9 @@ using System.Collections.Frozen;
 using System.Reflection;
 using System.Text.Json;
 using Jobby.Core.Interfaces.Queues;
+using Jobby.Core.Interfaces.Schedulers;
 using Jobby.Core.Services.Queues;
+using Jobby.Core.Services.Schedulers;
 
 namespace Jobby.Core.Services;
 
@@ -49,6 +51,7 @@ public class JobbyBuilder : IJobbyComponentsConfigurable, IJobbyJobsConfigurable
     private JobbyServerSettings _serverSettings = new();
 
     private string? _defaultRecurrentQueue;
+    private readonly Dictionary<string, IScheduler> _schedulersByType = JobbySchedulerTypes.CreateSchedulers();
     
     public bool IsExecutionScopeFactorySpecified => _scopeFactory != null;
     public bool IsLoggerFactorySpecified => _loggerFactory != null;
@@ -92,8 +95,8 @@ public class JobbyBuilder : IJobbyComponentsConfigurable, IJobbyJobsConfigurable
 
         IJobPostProcessingService postProcessingService = new JobPostProcessingService(storage,
             completionService,
-            LoggerFactory.CreateLogger<JobPostProcessingService>(),
-            serverId);
+            _schedulersByType.ToFrozenDictionary(),
+            LoggerFactory.CreateLogger<JobPostProcessingService>());
 
         IJobExecutionService executionService = new JobExecutionService(_scopeFactory,
             _jobsRegistry,
@@ -119,7 +122,11 @@ public class JobbyBuilder : IJobbyComponentsConfigurable, IJobbyJobsConfigurable
 
     public IJobsFactory CreateJobsFactory()
     {
-        _jobsFactory ??= new JobsFactory(GuidGenerator, Serializer, _defaultRecurrentQueue);
+        _jobsFactory ??= new JobsFactory(GuidGenerator,
+            Serializer,
+            _schedulersByType.ToFrozenDictionary(),
+            _defaultRecurrentQueue);
+        
         return _jobsFactory;
     }
 
@@ -289,6 +296,12 @@ public class JobbyBuilder : IJobbyComponentsConfigurable, IJobbyJobsConfigurable
     public IJobbyComponentsConfigurable UseTracing()
     {
         _tracingMiddleware ??= new TracingMiddleware();
+        return this;
+    }
+
+    public IJobbyComponentsConfigurable UseScheduler(string schedulerType, IScheduler scheduler)
+    {
+        _schedulersByType[schedulerType] = scheduler;
         return this;
     }
 

--- a/src/Jobby.Core/Services/JobbyClient.cs
+++ b/src/Jobby.Core/Services/JobbyClient.cs
@@ -75,18 +75,39 @@ internal class JobbyClient : IJobbyClient
         await _storage.InsertJobAsync(job);
         return job.Id;
     }
+    
+    public async Task<Guid> ScheduleRecurrentAsync<TCommand>(TCommand command,
+        string cron,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand
+    {
+        var job = _jobFactory.CreateRecurrent(command, cron, opts);
+        await _storage.InsertJobAsync(job);
+        return job.Id;
+    }
 
-    public void ScheduleRecurrent<TCommand>(TCommand command, string cron, RecurrentJobOpts opts = default)
-        where TCommand : IJobCommand
+    public async Task<Guid> ScheduleRecurrentAsync<TCommand>(TCommand command,
+        string schedule,
+        string schedulerType,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand
+    {
+        var job = _jobFactory.CreateRecurrent(command, schedule, schedulerType, opts);
+        await _storage.InsertJobAsync(job);
+        return job.Id;
+    }
+
+    public Guid ScheduleRecurrent<TCommand>(TCommand command,
+        string cron,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand
     {
         var job = _jobFactory.CreateRecurrent(command, cron, opts);
         _storage.InsertJob(job);
+        return job.Id;
     }
-
-    public Task ScheduleRecurrentAsync<TCommand>(TCommand command, string cron, RecurrentJobOpts opts = default)
-        where TCommand : IJobCommand
+    
+    public Guid ScheduleRecurrent<TCommand>(TCommand command, string schedule, string schedulerType,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand
     {
-        var job = _jobFactory.CreateRecurrent(command, cron, opts);
-        return _storage.InsertJobAsync(job);
-    }
+        var job = _jobFactory.CreateRecurrent(command, schedule, schedulerType, opts);
+        _storage.InsertJob(job);
+        return job.Id;    }
 }

--- a/src/Jobby.Core/Services/JobsFactory.cs
+++ b/src/Jobby.Core/Services/JobsFactory.cs
@@ -1,8 +1,9 @@
-﻿using System.IO.Pipes;
+﻿using Jobby.Core.Exceptions;
 using Jobby.Core.Helpers;
 using Jobby.Core.Interfaces;
-using Jobby.Core.Interfaces.Queues;
+using Jobby.Core.Interfaces.Schedulers;
 using Jobby.Core.Models;
+using Jobby.Core.Services.Schedulers;
 
 namespace Jobby.Core.Services;
 
@@ -10,14 +11,17 @@ internal class JobsFactory : IJobsFactory
 {
     private readonly IGuidGenerator _guidGenerator;
     private readonly IJobParamSerializer _serializer;
+    private readonly IReadOnlyDictionary<string, IScheduler> _schedulersByType;
     private readonly string _defaultQueueForRecurrent;
 
     public JobsFactory(IGuidGenerator guidGenerator,
         IJobParamSerializer serializer,
+        IReadOnlyDictionary<string, IScheduler> schedulersByType,
         string? defaultQueueForRecurrent)
     {
         _guidGenerator = guidGenerator;
         _serializer = serializer;
+        _schedulersByType = schedulersByType;
         _defaultQueueForRecurrent = defaultQueueForRecurrent ?? QueueSettings.DefaultQueueName;
     }
 
@@ -59,9 +63,23 @@ internal class JobsFactory : IJobsFactory
         return Create(command, new JobOpts { StartTime = startTime });
     }
 
-    public JobCreationModel CreateRecurrent<TCommand>(TCommand command, string cron, RecurrentJobOpts opts = default)
-        where TCommand : IJobCommand
+    public JobCreationModel CreateRecurrent<TCommand>(TCommand command,
+        string cron,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand
     {
+        return CreateRecurrent(command, cron, JobbySchedulerTypes.CronFromNow, opts);
+    }
+
+    public JobCreationModel CreateRecurrent<TCommand>(TCommand command, 
+        string schedule,
+        string schedulerType,
+        RecurrentJobOpts opts = default) where TCommand : IJobCommand
+    {
+        if (!_schedulersByType.TryGetValue(schedulerType, out var scheduler))
+        {
+            throw new UnknownSchedulerTypeException($"Unknown scheduler type: {schedulerType}");
+        }
+        
         var jobName = TCommand.GetJobName();
         var defaultOpts = default(RecurrentJobOpts);
         if (command is IHasDefaultJobOptions hasDefaultOpts)
@@ -74,13 +92,14 @@ internal class JobsFactory : IJobsFactory
             Id = _guidGenerator.NewGuid(),
             JobParam = _serializer.SerializeJobParam(command),
             JobName = jobName,
-            Cron = cron,
+            Cron = schedule,
+            SchedulerType = schedulerType,
             IsExclusive = opts.IsExclusive ?? defaultOpts.IsExclusive ?? true,
             CreatedAt = DateTime.UtcNow,
             Status = JobStatus.Scheduled,
             ScheduledStartAt = opts.StartTime 
                                ?? defaultOpts.StartTime
-                               ?? CronHelper.GetNext(cron, DateTime.UtcNow),
+                               ?? scheduler.GetNextStartTime(schedule, previousScheduledStartTime: null),
             CanBeRestarted = opts.CanBeRestartedIfServerGoesDown
                              ??  defaultOpts.CanBeRestartedIfServerGoesDown
                              ?? true,

--- a/src/Jobby.Core/Services/Schedulers/CronScheduler.cs
+++ b/src/Jobby.Core/Services/Schedulers/CronScheduler.cs
@@ -1,0 +1,26 @@
+﻿using Jobby.Core.Helpers;
+using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Schedulers;
+
+namespace Jobby.Core.Services.Schedulers;
+
+internal class CronScheduler : IScheduler
+{
+    private readonly ITimerService _timerService;
+    private readonly bool _calculateNextFromPrev;
+
+    public CronScheduler(ITimerService timerService, bool calculateNextFromPrev = false)
+    {
+        _timerService = timerService;
+        _calculateNextFromPrev = calculateNextFromPrev;
+    }
+
+    public DateTime GetNextStartTime(string schedule, DateTime? previousScheduledStartTime)
+    {
+        var from = previousScheduledStartTime.HasValue && _calculateNextFromPrev 
+            ? previousScheduledStartTime.Value
+            : _timerService.GetUtcNow();
+        
+        return CronHelper.GetNext(schedule, from);
+    }
+}

--- a/src/Jobby.Core/Services/Schedulers/JobbySchedulerTypes.cs
+++ b/src/Jobby.Core/Services/Schedulers/JobbySchedulerTypes.cs
@@ -1,0 +1,22 @@
+﻿using Jobby.Core.Interfaces.Schedulers;
+
+namespace Jobby.Core.Services.Schedulers;
+
+public static class JobbySchedulerTypes
+{
+    public const string CronFromNow = "CRON_FROM_NOW";
+    public const string CronFromPrev = "CRON_FROM_PREV";
+    public const string TimeSpanFromNow = "TIMESPAN_FROM_NOW";
+    public const string TimeSpanFromPrev = "TIMESPAN_FROM_PREV";
+
+    public static Dictionary<string, IScheduler> CreateSchedulers()
+    {
+        return new()
+        {
+            [CronFromNow] = new CronScheduler(TimerService.Instance, calculateNextFromPrev: false),
+            [CronFromPrev] = new CronScheduler(TimerService.Instance, calculateNextFromPrev: true),
+            [TimeSpanFromNow] = new TimeSpanScheduler(TimerService.Instance, calculateNextFromPrev: false),
+            [TimeSpanFromPrev] = new TimeSpanScheduler(TimerService.Instance, calculateNextFromPrev: true)
+        };
+    }
+}

--- a/src/Jobby.Core/Services/Schedulers/TimeSpanScheduler.cs
+++ b/src/Jobby.Core/Services/Schedulers/TimeSpanScheduler.cs
@@ -1,0 +1,28 @@
+﻿using System.Globalization;
+using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Schedulers;
+
+namespace Jobby.Core.Services.Schedulers;
+
+internal class TimeSpanScheduler : IScheduler
+{
+    private readonly ITimerService _timerService;
+    private readonly bool _calculateNextFromPrev;
+
+    public TimeSpanScheduler(ITimerService timerService, bool calculateNextFromPrev)
+    {
+        _timerService = timerService;
+        _calculateNextFromPrev = calculateNextFromPrev;
+    }
+
+    public DateTime GetNextStartTime(string schedule, DateTime? previousScheduledStartTime)
+    {
+        var span = TimeSpan.Parse(schedule, CultureInfo.InvariantCulture);
+        
+        var from = previousScheduledStartTime.HasValue && _calculateNextFromPrev
+            ? previousScheduledStartTime.Value
+            : _timerService.GetUtcNow();
+        
+        return from.Add(span);
+    }
+}

--- a/src/Jobby.Core/Services/TimerService.cs
+++ b/src/Jobby.Core/Services/TimerService.cs
@@ -21,4 +21,9 @@ internal class TimerService : ITimerService
     {
         return Stopwatch.GetElapsedTime(startTicks);
     }
+
+    public DateTime GetUtcNow()
+    {
+        return DateTime.UtcNow;
+    }
 }

--- a/src/Jobby.Postgres/Commands/BulkInsertJobsCommand.cs
+++ b/src/Jobby.Postgres/Commands/BulkInsertJobsCommand.cs
@@ -21,15 +21,26 @@ internal class BulkInsertJobsCommand
                 status,
                 created_at,
                 scheduled_start_at,
+                cron,
                 next_job_id,
                 can_be_restarted,
-                cron,
                 queue_name,
                 serializable_group_id,
                 lock_group_if_failed,
-                is_exclusive
+                is_exclusive,
+                scheduler_type
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            ON CONFLICT (job_name) WHERE is_exclusive=true DO
+            UPDATE SET
+                id = $1,
+                job_param = $3,
+	            cron = $7,
+	            scheduled_start_at = $6,
+                can_be_restarted = $9,
+                queue_name = $10,
+                serializable_group_id = $11,
+                scheduler_type = $14
         ";
     }
 
@@ -63,19 +74,20 @@ internal class BulkInsertJobsCommand
             {
                 Parameters =
                 {
-                    new() { Value = job.Id },
-                    new() { Value = job.JobName },
-                    new() { Value = (object?)job.JobParam ?? DBNull.Value },
-                    new() { Value = (int)job.Status },
-                    new() { Value = job.CreatedAt },
-                    new() { Value = job.ScheduledStartAt },
-                    new() { Value = (object?)job.NextJobId ?? DBNull.Value },
-                    new() { Value = job.CanBeRestarted },
-                    new() { Value = (object?)job.Cron ?? DBNull.Value },
-                    new() { Value = job.QueueName },
-                    new() { Value = (object?)job.SerializableGroupId ?? DBNull.Value },
-                    new() { Value = job.LockGroupIfFailed },
-                    new() { Value = job.IsExclusive },
+                    new() { Value = job.Id },                                           // 1
+                    new() { Value = job.JobName },                                      // 2
+                    new() { Value = (object?)job.JobParam ?? DBNull.Value },            // 3
+                    new() { Value = (int)job.Status },                                  // 4
+                    new() { Value = job.CreatedAt },                                    // 5
+                    new() { Value = job.ScheduledStartAt },                             // 6
+                    new() { Value = (object?)job.Cron ?? DBNull.Value },                // 7
+                    new() { Value = (object?)job.NextJobId ?? DBNull.Value },           // 8
+                    new() { Value = job.CanBeRestarted },                               // 9
+                    new() { Value = job.QueueName },                                    // 10
+                    new() { Value = (object?)job.SerializableGroupId ?? DBNull.Value }, // 11
+                    new() { Value = job.LockGroupIfFailed },                            // 12
+                    new() { Value = job.IsExclusive },                                  // 13
+                    new() { Value = (object?)job.SchedulerType ?? DBNull.Value },       // 14
                 }
             };
             batch.BatchCommands.Add(cmd);

--- a/src/Jobby.Postgres/Commands/InsertJobCommand.cs
+++ b/src/Jobby.Postgres/Commands/InsertJobCommand.cs
@@ -27,9 +27,10 @@ internal class InsertJobCommand
                 queue_name,
                 serializable_group_id,
                 lock_group_if_failed,
-                is_exclusive
+                is_exclusive,
+                scheduler_type
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
             ON CONFLICT (job_name) WHERE is_exclusive=true DO
             UPDATE SET
                 id = $1,
@@ -38,7 +39,8 @@ internal class InsertJobCommand
 	            scheduled_start_at = $6,
                 can_be_restarted = $9,
                 queue_name = $10,
-                serializable_group_id = $11
+                serializable_group_id = $11,
+                scheduler_type = $14
         ";
     }
 
@@ -61,6 +63,7 @@ internal class InsertJobCommand
                 new() { Value = (object?)job.SerializableGroupId ?? DBNull.Value }, // 11
                 new() { Value = job.LockGroupIfFailed },                            // 12
                 new() { Value = job.IsExclusive },                                  // 13
+                new() { Value = (object?)job.SchedulerType ?? DBNull.Value },       // 14
             }
         };
     }

--- a/src/Jobby.Postgres/Commands/TakeBatchToProcessingCommand.cs
+++ b/src/Jobby.Postgres/Commands/TakeBatchToProcessingCommand.cs
@@ -36,9 +36,9 @@ internal class TakeBatchToProcessingCommand
 	                    started_count = started_count + 1,
                         server_id = $3
                     WHERE id IN (SELECT id FROM ready_jobs)
-                    RETURNING id, job_name, job_param, started_count, cron, next_job_id, scheduled_start_at, server_id
+                    RETURNING id, job_name, job_param, started_count, cron, next_job_id, scheduled_start_at, server_id, scheduler_type
                 )
-            SELECT id, job_name, job_param, started_count, cron, next_job_id, scheduled_start_at, server_id
+            SELECT id, job_name, job_param, started_count, cron, next_job_id, scheduled_start_at, server_id, scheduler_type
             FROM updated
         ";
     }

--- a/src/Jobby.Postgres/Helpers/DataReaderExtensions.cs
+++ b/src/Jobby.Postgres/Helpers/DataReaderExtensions.cs
@@ -28,6 +28,7 @@ internal static class DataReaderExtensions
             NextJobId = reader.GetNullableGuid("next_job_id"),
             ServerId =  reader.GetString(reader.GetOrdinal("server_id")),
             ScheduledStartAt = reader.GetDateTime(reader.GetOrdinal("scheduled_start_at")),
+            SchedulerType = reader.GetNullableString("scheduler_type"),
         };
         return job;
     }

--- a/src/Jobby.Postgres/Migrations/V1_0_0_20260204_2108__SerializableGroups.sql
+++ b/src/Jobby.Postgres/Migrations/V1_0_0_20260204_2108__SerializableGroups.sql
@@ -27,7 +27,8 @@ RETURNS TABLE (
     cron TEXT,
     next_job_id uuid,
     scheduled_start_at timestamptz,
-    server_id TEXT
+    server_id TEXT,
+    scheduler_type TEXT
 )
 LANGUAGE plpgsql
 AS $$
@@ -100,7 +101,8 @@ BEGIN
                         t.cron AS r_cron,
                         t.next_job_id AS r_next_job_id,
                         t.scheduled_start_at AS r_scheduled_start_at,
-                        t.server_id AS r_server_id
+                        t.server_id AS r_server_id,
+                        t.scheduler_type AS r_scheduler_type
                 ),
                 skipped AS (
                     SELECT
@@ -112,7 +114,8 @@ BEGIN
                         NULL AS r_cron,
                         NULL::uuid AS r_next_job_id,
                         NULL::timestamptz AS r_scheduled_start_at,
-                        NULL AS r_server_id
+                        NULL AS r_server_id,
+                        NULL AS r_scheduler_type
                     FROM candidates c 
                     WHERE c.serializable_group_id IS NOT NULL 
                     AND c.id NOT IN (
@@ -132,6 +135,7 @@ BEGIN
                     next_job_id := rec.r_next_job_id;
                     scheduled_start_at := rec.r_scheduled_start_at;
                     server_id := rec.r_server_id;
+                    scheduler_type := rec.r_scheduler_type;
                     
                     RETURN NEXT;
                     

--- a/src/Jobby.Postgres/Migrations/V1_0_0_20260218_2314__SchedulerType.sql
+++ b/src/Jobby.Postgres/Migrations/V1_0_0_20260218_2314__SchedulerType.sql
@@ -1,0 +1,2 @@
+﻿ALTER TABLE ${jobs_table_fullname}
+    ADD COLUMN IF NOT EXISTS scheduler_type TEXT DEFAULT NULL;

--- a/src/Jobby.Postgres/jobby.sql
+++ b/src/Jobby.Postgres/jobby.sql
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS jobby_jobs (
             )
         )
     ) STORED,
-    is_exclusive BOOLEAN NOT NULL DEFAULT FALSE
+    is_exclusive BOOLEAN NOT NULL DEFAULT FALSE,
+    scheduler_type TEXT DEFAULT NULL
 );
 
 CREATE INDEX IF NOT EXISTS jobby_jobs_queue_name_status_scheduled_start_at_idx
@@ -58,7 +59,8 @@ RETURNS TABLE (
     cron TEXT,
     next_job_id uuid,
     scheduled_start_at timestamptz,
-    server_id TEXT
+    server_id TEXT,
+    scheduler_type TEXT
 )
 LANGUAGE plpgsql
 AS $$
@@ -88,10 +90,10 @@ BEGIN
                     AND (
                         c.serializable_group_id IS NULL
                         OR NOT EXISTS (
-                            SELECT 1 FROM jobby_jobs jl 
+                            SELECT 1 FROM jobby_jobs jl
                             WHERE
                                 jl.serializable_group_id = c.serializable_group_id
-                                AND jl.is_group_locker = TRUE 
+                                AND jl.is_group_locker = TRUE
                                 AND jl.id != c.id
                         )
                     )
@@ -131,7 +133,8 @@ BEGIN
                         t.cron AS r_cron,
                         t.next_job_id AS r_next_job_id,
                         t.scheduled_start_at AS r_scheduled_start_at,
-                        t.server_id AS r_server_id
+                        t.server_id AS r_server_id,
+                        t.scheduler_type AS r_scheduler_type
                 ),
                 skipped AS (
                     SELECT
@@ -143,7 +146,8 @@ BEGIN
                         NULL AS r_cron,
                         NULL::uuid AS r_next_job_id,
                         NULL::timestamptz AS r_scheduled_start_at,
-                        NULL AS r_server_id
+                        NULL AS r_server_id,
+                        NULL AS r_scheduler_type
                     FROM candidates c 
                     WHERE c.serializable_group_id IS NOT NULL 
                     AND c.id NOT IN (
@@ -163,6 +167,7 @@ BEGIN
                     next_job_id := rec.r_next_job_id;
                     scheduled_start_at := rec.r_scheduled_start_at;
                     server_id := rec.r_server_id;
+                    scheduler_type := rec.r_scheduler_type;
                     
                     RETURN NEXT;
                     

--- a/tests/Jobby.IntegrationTests.Postgres/Helpers/AssertHelper.cs
+++ b/tests/Jobby.IntegrationTests.Postgres/Helpers/AssertHelper.cs
@@ -24,5 +24,6 @@ internal static class AssertHelper
         Assert.Equal(expected.SerializableGroupId, actual.SerializableGroupId);
         Assert.Equal(expected.LockGroupIfFailed, actual.LockGroupIfFailed);
         Assert.Equal(expected.IsExclusive, actual.IsExclusive);
+        Assert.Equal(expected.SchedulerType, actual.SchedulerType);
     }    
 }

--- a/tests/Jobby.IntegrationTests.Postgres/Helpers/JobDbModel.cs
+++ b/tests/Jobby.IntegrationTests.Postgres/Helpers/JobDbModel.cs
@@ -60,6 +60,9 @@ internal class JobDbModel
     [Column("is_exclusive")]
     public bool IsExclusive { get; set; }
 
+    [Column("scheduler_type")]
+    public string? SchedulerType { get; set; }
+
     public JobExecutionModel ToJobExecutionModel()
     {
         return new JobExecutionModel

--- a/tests/Jobby.IntegrationTests.Postgres/JobbyClientIntegrationTests.cs
+++ b/tests/Jobby.IntegrationTests.Postgres/JobbyClientIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿using Jobby.Core.Interfaces;
 using Jobby.Core.Models;
 using Jobby.Core.Services;
+using Jobby.Core.Services.Schedulers;
 using Jobby.IntegrationTests.Postgres.Helpers;
 using Jobby.Postgres.ConfigurationExtensions;
 using Jobby.TestsUtils.Jobs;
@@ -169,6 +170,7 @@ public class JobbyClientIntegrationTests
                                              .Where(x => x.JobName == TestJobCommand.GetJobName() && x.Cron == cron)
                                              .FirstOrDefaultAsync();
         Assert.NotNull(actualJobFromDb);
+        Assert.Equal(JobbySchedulerTypes.CronFromNow, actualJobFromDb.SchedulerType);
 
         await client.CancelRecurrentAsync<TestJobCommand>();
 
@@ -186,12 +188,13 @@ public class JobbyClientIntegrationTests
 
         var command = new TestJobCommand();
         var cron = "0 3 1 1 *";
-        client.ScheduleRecurrent(command, cron);
+        client.ScheduleRecurrent(command, cron, JobbySchedulerTypes.CronFromPrev);
 
         var actualJobFromDb = dbContext.Jobs
             .AsNoTracking()
             .FirstOrDefault(x => x.JobName == TestJobCommand.GetJobName() && x.Cron == cron);
         Assert.NotNull(actualJobFromDb);
+        Assert.Equal(JobbySchedulerTypes.CronFromPrev, actualJobFromDb.SchedulerType);
 
         client.CancelRecurrent<TestJobCommand>();
 

--- a/tests/Jobby.IntegrationTests.Postgres/PostgresqlJobbyStorageTests/TakeBatchToProcessingTests.cs
+++ b/tests/Jobby.IntegrationTests.Postgres/PostgresqlJobbyStorageTests/TakeBatchToProcessingTests.cs
@@ -19,6 +19,7 @@ public class TakeBatchToProcessingTests
             Id = Guid.NewGuid(),
             JobName = "firstJob",
             Cron = "*/20 * * * *",
+            SchedulerType = "scheduler-type",
             JobParam = "param1",
             StartedCount = 1,
             NextJobId = Guid.NewGuid(),
@@ -289,6 +290,7 @@ public class TakeBatchToProcessingTests
         Assert.Equal(createdJob.JobParam, takenJob.JobParam);
         Assert.Equal(createdJob.StartedCount + 1, takenJob.StartedCount);
         Assert.Equal(createdJob.NextJobId, takenJob.NextJobId);
+        Assert.Equal(createdJob.SchedulerType, takenJob.SchedulerType);
         Assert.Equal(serverId, takenJob.ServerId);
     }
 

--- a/tests/Jobby.Tests.Core/Services/JobPostProcessingServiceTests.cs
+++ b/tests/Jobby.Tests.Core/Services/JobPostProcessingServiceTests.cs
@@ -1,10 +1,10 @@
-﻿using Jobby.Core.Helpers;
-using Jobby.Core.Interfaces;
+﻿using Jobby.Core.Interfaces;
 using Jobby.Core.Models;
 using Jobby.Core.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Linq.Expressions;
+using Jobby.Core.Interfaces.Schedulers;
 
 namespace Jobby.Tests.Core.Services;
 
@@ -13,21 +13,27 @@ public class JobPostProcessingServiceTests
     private readonly Mock<IJobbyStorage> _storageMock;
     private readonly Mock<IJobCompletionService> _completionServiceMock;
     private readonly Mock<ILogger<JobPostProcessingService>> _loggerMock;
+    private readonly Mock<IScheduler> _schedulerMock;
 
     private readonly JobPostProcessingService _postProcessingService;
 
-    private const string ServerId = "serverId";
+    private const string SchedulerType = "scheduler-type";
 
     public JobPostProcessingServiceTests()
     {
         _storageMock = new Mock<IJobbyStorage>();
         _completionServiceMock = new Mock<IJobCompletionService>();
         _loggerMock = new Mock<ILogger<JobPostProcessingService>>();
+        _schedulerMock = new Mock<IScheduler>();
+        var schedulers = new Dictionary<string, IScheduler>
+        {
+            [SchedulerType] = _schedulerMock.Object,
+        };
         _postProcessingService = new JobPostProcessingService(
             _storageMock.Object,
             _completionServiceMock.Object,
-            _loggerMock.Object,
-            ServerId);
+            schedulers,
+            _loggerMock.Object);
     }
 
     [Fact]
@@ -95,14 +101,19 @@ public class JobPostProcessingServiceTests
         var job = new JobExecutionModel
         {
             Id = Guid.NewGuid(),
-            Cron = "0 3 1 12 *"
+            Cron = "0 3 1 12 *",
+            SchedulerType = SchedulerType,
+            ScheduledStartAt = DateTime.UtcNow,
         };
         var error = "error";
+        var expectedNextTime = DateTime.UtcNow.AddSeconds(123);
+        _schedulerMock
+            .Setup(x => x.GetNextStartTime(job.Cron, job.ScheduledStartAt))
+            .Returns(expectedNextTime);
 
         await _postProcessingService.RescheduleRecurrent(job, error);
 
-        Expression<Func<DateTime, bool>> expectedNewStartTime = x => CronHelper.GetNext(job.Cron, DateTime.UtcNow).Subtract(x) < TimeSpan.FromSeconds(1);
-        _storageMock.Verify(x => x.RescheduleProcessingJobAsync(job, It.Is(expectedNewStartTime), error), Times.Once());
+        _storageMock.Verify(x => x.RescheduleProcessingJobAsync(job, expectedNextTime, error), Times.Once());
         Assert.True(_postProcessingService.IsRetryQueueEmpty);
     }
 
@@ -165,7 +176,8 @@ public class JobPostProcessingServiceTests
         var job = new JobExecutionModel
         {
             Id = Guid.NewGuid(),
-            Cron = "0 3 1 12 *"
+            Cron = "0 3 1 12 *",
+            SchedulerType = SchedulerType
         };
         var error = "error";
         _storageMock
@@ -187,7 +199,10 @@ public class JobPostProcessingServiceTests
     public void Dispose_CallsDisposeInJobCompletionServiceIfItIsDisposable()
     {
         var completionService = new DisposableCompletionService();
-        var postProcessingService = new JobPostProcessingService(_storageMock.Object, completionService, _loggerMock.Object, ServerId);
+        var postProcessingService = new JobPostProcessingService(_storageMock.Object,
+            completionService, 
+            new Dictionary<string, IScheduler>(),
+            _loggerMock.Object);
 
         postProcessingService.Dispose();
 
@@ -196,7 +211,7 @@ public class JobPostProcessingServiceTests
 
     private class DisposableCompletionService : IJobCompletionService, IDisposable
     {
-        public bool Disposed { get; private set; } = false;
+        public bool Disposed { get; private set; }
 
         public Task CompleteJob(JobExecutionModel job)
         {

--- a/tests/Jobby.Tests.Core/Services/JobsFactoryTests.cs
+++ b/tests/Jobby.Tests.Core/Services/JobsFactoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using Jobby.Core.Helpers;
 using Jobby.Core.Interfaces;
+using Jobby.Core.Interfaces.Schedulers;
 using Jobby.Core.Models;
 using Jobby.Core.Services;
+using Jobby.Core.Services.Schedulers;
 using Jobby.TestsUtils.Jobs;
 using Moq;
 
@@ -35,6 +37,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Null(job.Cron);
+        Assert.Null(job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(DateTime.UtcNow, job.ScheduledStartAt, TimeSpan.FromSeconds(1));
@@ -59,6 +62,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Null(job.Cron);
+        Assert.Null(job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(startTime, job.ScheduledStartAt);
@@ -90,6 +94,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Null(job.Cron);
+        Assert.Null(job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(opts.StartTime.Value, job.ScheduledStartAt);
@@ -122,6 +127,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Null(job.Cron);
+        Assert.Null(job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(defaultOpts.StartTime.Value, job.ScheduledStartAt);
@@ -156,6 +162,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Null(job.Cron);
+        Assert.Null(job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(opts.StartTime.Value, job.ScheduledStartAt);
@@ -180,9 +187,43 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Equal(cron, job.Cron);
+        Assert.Equal(JobbySchedulerTypes.CronFromNow, job.SchedulerType);
         Assert.True(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         var expectedStartTime = CronHelper.GetNext(cron, job.CreatedAt);
+        Assert.Equal(expectedStartTime, job.ScheduledStartAt);
+        Assert.Null(job.NextJobId);
+        Assert.Equal(QueueSettings.DefaultQueueName, job.QueueName);
+        Assert.True(job.CanBeRestarted);
+    }
+    
+    [Fact]
+    public void CreateRecurrent_CustomScheduler_CreatesJobModelWithStartTimeCalculatedByCustomScheduler()
+    {
+        var command = new TestJobCommand();
+        _serializerMock.Setup(x => x.SerializeJobParam(command)).Returns(SerializedCommand);
+        var schedule = "custom-schedule";
+        var schedulerType = "custom-scheduler";
+        var schedulerMock = new Mock<IScheduler>();
+        var expectedStartTime = DateTime.UtcNow.AddMinutes(123);
+        schedulerMock
+            .Setup(x => x.GetNextStartTime(schedule, null))
+            .Returns(expectedStartTime);
+        var schedulers = new Dictionary<string, IScheduler>
+        {
+            [schedulerType] = schedulerMock.Object
+        };
+
+        var job = GetFactory(schedulers: schedulers).CreateRecurrent(command, schedule, schedulerType);
+
+        Assert.Equal(JobId,  job.Id);
+        Assert.Equal(TestJobCommand.GetJobName(), job.JobName);
+        Assert.Equal(SerializedCommand, job.JobParam);
+        Assert.Equal(JobStatus.Scheduled, job.Status);
+        Assert.Equal(schedule, job.Cron);
+        Assert.Equal(schedulerType, job.SchedulerType);
+        Assert.True(job.IsExclusive);
+        Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(expectedStartTime, job.ScheduledStartAt);
         Assert.Null(job.NextJobId);
         Assert.Equal(QueueSettings.DefaultQueueName, job.QueueName);
@@ -211,6 +252,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Equal(cron, job.Cron);
+        Assert.Equal(JobbySchedulerTypes.CronFromNow, job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(opts.StartTime.Value, job.ScheduledStartAt);
@@ -242,6 +284,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Equal(cron, job.Cron);
+        Assert.Equal(JobbySchedulerTypes.CronFromNow, job.SchedulerType);
         Assert.True(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(defaultOpts.StartTime.Value, job.ScheduledStartAt);
@@ -277,6 +320,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Equal(cron, job.Cron);
+        Assert.Equal(JobbySchedulerTypes.CronFromNow, job.SchedulerType);
         Assert.False(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         Assert.Equal(opts.StartTime.Value, job.ScheduledStartAt);
@@ -302,6 +346,7 @@ public class JobsFactoryTests
         Assert.Equal(SerializedCommand, job.JobParam);
         Assert.Equal(JobStatus.Scheduled, job.Status);
         Assert.Equal(cron, job.Cron);
+        Assert.Equal(JobbySchedulerTypes.CronFromNow, job.SchedulerType);
         Assert.True(job.IsExclusive);
         Assert.Equal(DateTime.UtcNow, job.CreatedAt, TimeSpan.FromSeconds(1));
         var expectedStartTime = CronHelper.GetNext(cron, job.CreatedAt);
@@ -309,10 +354,13 @@ public class JobsFactoryTests
         Assert.Null(job.NextJobId);
         Assert.Equal(defaultRecurrentQueue, job.QueueName);
         Assert.True(job.CanBeRestarted);
-    }    
+    }
     
-    private JobsFactory GetFactory(string? defaultRecurrentQueue = null)
+    private JobsFactory GetFactory(string? defaultRecurrentQueue = null, Dictionary<string, IScheduler>? schedulers = null)
     {
-        return new JobsFactory(_guidGeneratorMock.Object, _serializerMock.Object, defaultRecurrentQueue);
+        return new JobsFactory(_guidGeneratorMock.Object,
+            _serializerMock.Object,
+            schedulers ?? JobbySchedulerTypes.CreateSchedulers(),
+            defaultRecurrentQueue);
     }
 }

--- a/tests/Jobby.Tests.Core/Services/Schedulers/CronSchedulerTests.cs
+++ b/tests/Jobby.Tests.Core/Services/Schedulers/CronSchedulerTests.cs
@@ -1,0 +1,56 @@
+﻿using Jobby.Core.Helpers;
+using Jobby.Core.Interfaces;
+using Jobby.Core.Services.Schedulers;
+using Moq;
+
+namespace Jobby.Tests.Core.Services.Schedulers;
+
+public class CronSchedulerTests
+{
+    private readonly Mock<ITimerService> _timerService = new();
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PrevNotSpecified_CalculatesNextFromNow(bool calculateNextFromPrev)
+    {
+        var now = DateTime.UtcNow;
+        _timerService.Setup(x => x.GetUtcNow()).Returns(now);
+        
+        var schedule = "*/5 * * * *";
+        var scheduler = new CronScheduler(_timerService.Object, calculateNextFromPrev);
+        var next = scheduler.GetNextStartTime(schedule, null);
+        
+        var expectedNext = CronHelper.GetNext(schedule, now);
+        Assert.Equal(expectedNext, next);
+    }
+    
+    [Fact]
+    public void PrevSpecified_ConfiguredToCalculateFromNow_CalculatesNextFromNow()
+    {
+        var now = DateTime.UtcNow;
+        _timerService.Setup(x => x.GetUtcNow()).Returns(now);
+        
+        var schedule = "*/5 * * * *";
+        var scheduler = new CronScheduler(_timerService.Object, calculateNextFromPrev: false);
+        var next = scheduler.GetNextStartTime(schedule, DateTime.UtcNow.AddHours(-1));
+        
+        var expectedNext = CronHelper.GetNext(schedule, now);
+        Assert.Equal(expectedNext, next);
+    }
+    
+    [Fact]
+    public void PrevSpecified_ConfiguredToCalculateFromPrev_CalculatesNextFromPrev()
+    {
+        var now = DateTime.UtcNow;
+        _timerService.Setup(x => x.GetUtcNow()).Returns(now);
+        
+        var schedule = "*/5 * * * *";
+        var scheduler = new CronScheduler(_timerService.Object, calculateNextFromPrev: true);
+        var prev = DateTime.UtcNow.AddHours(-1);
+        var next = scheduler.GetNextStartTime(schedule, prev);
+        
+        var expectedNext = CronHelper.GetNext(schedule, prev);
+        Assert.Equal(expectedNext, next);
+    }
+}

--- a/tests/Jobby.Tests.Core/Services/Schedulers/TimeSpanSchedulerTests.cs
+++ b/tests/Jobby.Tests.Core/Services/Schedulers/TimeSpanSchedulerTests.cs
@@ -1,0 +1,56 @@
+﻿using Jobby.Core.Helpers;
+using Jobby.Core.Interfaces;
+using Jobby.Core.Services.Schedulers;
+using Moq;
+
+namespace Jobby.Tests.Core.Services.Schedulers;
+
+public class TimeSpanSchedulerTests
+{
+    private readonly Mock<ITimerService> _timerService = new();
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PrevNotSpecified_CalculatesNextFromNow(bool calculateNextFromPrev)
+    {
+        var now = DateTime.UtcNow;
+        _timerService.Setup(x => x.GetUtcNow()).Returns(now);
+        
+        var schedule = "00:00:05";
+        var scheduler = new TimeSpanScheduler(_timerService.Object, calculateNextFromPrev);
+        var next = scheduler.GetNextStartTime(schedule, null);
+        
+        var expectedNext = now.AddSeconds(5);
+        Assert.Equal(expectedNext, next);
+    }
+    
+    [Fact]
+    public void PrevSpecified_ConfiguredToCalculateFromNow_CalculatesNextFromNow()
+    {
+        var now = DateTime.UtcNow;
+        _timerService.Setup(x => x.GetUtcNow()).Returns(now);
+        
+        var schedule = "00:00:05";
+        var scheduler = new TimeSpanScheduler(_timerService.Object, calculateNextFromPrev: false);
+        var next = scheduler.GetNextStartTime(schedule, DateTime.UtcNow.AddHours(-1));
+        
+        var expectedNext = now.AddSeconds(5);
+        Assert.Equal(expectedNext, next);
+    }
+    
+    [Fact]
+    public void PrevSpecified_ConfiguredToCalculateFromPrev_CalculatesNextFromPrev()
+    {
+        var now = DateTime.UtcNow;
+        _timerService.Setup(x => x.GetUtcNow()).Returns(now);
+        
+        var schedule = "00:00:05";
+        var scheduler = new TimeSpanScheduler(_timerService.Object, calculateNextFromPrev: true);
+        var prev = DateTime.UtcNow.AddHours(-1);
+        var next = scheduler.GetNextStartTime(schedule, prev);
+        
+        var expectedNext = prev.AddSeconds(5);
+        Assert.Equal(expectedNext, next);
+    }
+}


### PR DESCRIPTION
By default, recurrent jobs use a cron expression as their schedule. The next execution time is always calculated relative to the current time (either at the moment the job is created or when its current run finishes):

```csharp
jobbyClient.ScheduleRecurrent(command, "*/5 * * * *");
```

Jobby now supports several other ways to define the schedule:

```csharp
// Also cron, but the next execution time is calculated 
// relative to the previously scheduled time
jobbyClient.ScheduleRecurrent(command, "*/5 * * * *", JobbySchedulerTypes.CronFromPrev);

// Schedule in TimeSpan format
// The specified interval is added to the current time to calculate the next execution
jobbyClient.ScheduleRecurrent(command, "00:05:00", JobbySchedulerTypes.TimeSpanFromNow);

// Or added to the previously scheduled execution time
jobbyClient.ScheduleRecurrent(command, "00:05:00", JobbySchedulerTypes.TimeSpanFromPrev);
```

You can also implement your own logic for calculating execution times with a custom schedule format. To do this:

```csharp
// Implement the IScheduler interface
public class CustomSecondsScheduler : IScheduler
{    
    public DateTime GetNextStartTime(string schedule, DateTime? previousScheduledStartTime)
    {
        var seconds = int.Parse(schedule);
        return previousScheduledStartTime?.AddSeconds(seconds) ?? DateTime.UtcNow;
    }
}

// Register your implementation when configuring the library
 jobby
    .UsePostgresql(sp.GetRequiredService<NpgsqlDataSource>())
    .UseScheduler("my-own-scheduler", new CustomSecondsScheduler())

// Now you can use your custom schedulerType when creating jobs
jobbyClient.ScheduleRecurrent(command, "5", "my-own-scheduler");
```

Also now you can specify concrete StartTime for the first run:

```csharp
// first time job will start immediately after creation
// and then - every 5 minutes
jobbyClient.ScheduleRecurrent(command, "00:05:00", JobbySchedulerTypes.TimeSpanFromPrev, new RecurrentJobOpts
{
    // when job should be started first time
    StartTime: DateTime.UtcNow
});


```